### PR TITLE
Different Wiring than old Montex

### DIFF
--- a/keyboards/idobao/montex/v2/keymaps/default/keymap.c
+++ b/keyboards/idobao/montex/v2/keymaps/default/keymap.c
@@ -36,10 +36,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [0] = LAYOUT_numpad_6x5(
         KC_GRAVE,  KC_ESC,  KC_TAB,  MO(1),   KC_BSPC,
         KC_COMMA,  KC_NLCK, KC_PSLS, KC_PAST, KC_PMNS,
-        KC_LGUI,   KC_P7,   KC_P8,   KC_P9,
-        KC_LALT,   KC_P4,   KC_P5,   KC_P6,   KC_PPLS,
-        KC_LSHIFT, KC_P1,   KC_P2,   KC_P3,
-        KC_LCTRL,  KC_P0,            KC_PDOT, KC_PENT
+        KC_LGUI,   KC_P7,   KC_P8,   KC_P9,   KC_PPLS,
+        KC_LALT,   KC_P4,   KC_P5,   KC_P6,
+        KC_LSHIFT, KC_P1,   KC_P2,   KC_P3,   KC_PENT,
+        KC_LCTRL,  KC_P0,            KC_PDOT
     ),
 
     /*
@@ -60,10 +60,10 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [1] = LAYOUT_numpad_6x5(
         RESET,   RGB_TOG, RGB_MOD, _______, _______,
         _______, _______, _______, _______, _______,
-        RGB_SPI, RGB_HUI, RGB_SAI, RGB_VAI,
-        RGB_SPD, RGB_HUD, RGB_SAD, RGB_VAD, _______,
-        _______, _______, _______, _______,
-        _______, _______,           _______,  _______
+        RGB_SPI, RGB_HUI, RGB_SAI, RGB_VAI, _______,
+        RGB_SPD, RGB_HUD, RGB_SAD, RGB_VAD, 
+        _______, _______, _______, _______, _______,
+        _______, _______,           _______  
     )
 
 };


### PR DESCRIPTION
Hello,

I received the RGB Montex today and I flashed something based on your work. I noticed, that the 
wiring is different than in the old model without RGB. The "+" Sign and the "Enter" Key are now one row further up,
which moved some keys arround (starting from row 4).

Maybe this issue is just different hardware revisions. idk. But with this changes, all keys on the MontexV2 are working
perfectly on my unit here.

Thank you very much for you work and effort :)

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
