### PR TITLE
Update config.h

### DIFF
--- a/keyboards/idobao/montex/v2/config.h
+++ b/keyboards/idobao/montex/v2/config.h
@@ -7,7 +7,7 @@
 
 /* USB Device descriptor parameter */
 #define VENDOR_ID       0x6964  // "id"
-#define PRODUCT_ID      0x6060
+#define PRODUCT_ID      0x0027
 #define DEVICE_VER      0x0002
 #define MANUFACTURER    IDOBAO
 #define PRODUCT         Montex


### PR DESCRIPTION
Because the keymap of the v1 is different from the v2 we'll need to change the `PRODUCT_ID` on v2.  This is because the USB-ID *(that VIA uses to identify the KB)* is only the value `0xVVVVPPPP`.  (Where *VVVV* = `VENDOR_ID` (hex), and *PPPP* = `PRODUCT_ID`).
`DEVICE_VER` is not used in the VIA matching.  This means that someone using a V2 may get a V1 VIA map and thus map incorrectly.   Changing the `PRODUCT_ID` creates new identifier, that VIA can use to disseminate between v1 and v2.

I chose to use `0x0027` as it uses the same numbering used in the other Idobo KB's ... 27 being the key count.  *(Montex has 27 keys.  And yes I know the 0x27 hex is not 27 binary, but that's how the other kb are marked.)*  It can be any value, but the same as the others seems like a good choice.

Also probably why sigprof has not approved your PR on this one :(